### PR TITLE
Temp comment out of typeDefs/resolvers in server.js

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "^4.7.1",
-        "apollo-server-express": "^3.6.2",
+        "apollo-server-express": "^3.13.0",
         "bcrypt": "^5.0.0",
         "express": "^4.17.2",
         "graphql": "^16.6.0",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@apollo/server": "^4.7.1",
-    "apollo-server-express": "^3.6.2",
+    "apollo-server-express": "^3.13.0",
     "bcrypt": "^5.0.0",
     "express": "^4.17.2",
     "graphql": "^16.6.0",

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const { ApolloServer } = require('apollo-server-express');
-const { typeDefs, resolvers } = require('./schemas');
+// const { typeDefs, resolvers } = require('./schemas');
 
 const app = express();
 const PORT = process.env.PORT || 3001;


### PR DESCRIPTION
Updated ApolloServer package and temporarily commented out our typeDef/resolver requirement in server.js for testing on front end